### PR TITLE
scope content scripts to github domain only, fix #20

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": 
   [
     {
-      "matches": ["*://*/*"],
+      "matches": ["https://github.com/*"],
       "js": ["script/pageload/functions.js", "script/pageload/body.js", "script/pageload/callbacks.js"],
       "run_at": "document_end"
     }
@@ -25,7 +25,8 @@
   "permissions": [
     "activeTab",
     "https://ajax.googleapis.com/",
-    "https://gitcoin.co/"
+    "https://gitcoin.co/",
+    "https://*.github.com/*"
   ],
   "background":
   {


### PR DESCRIPTION
The patch fix #20 by scope content scripts to github domain, 
also add permission to communicate to addon from github pages

tested on Chrome and it works as v0.904